### PR TITLE
Corrected bash scripts to get the right id of containers

### DIFF
--- a/container/bin/backup_db.sh
+++ b/container/bin/backup_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get container id
-container=$(docker ps -qf "name=t3apprenticeship_db_1")
+container=$(docker ps -qf "name=masheuskirchen_db_1")
 
 # Backup database
 docker exec $container mysqldump -u typo3 --password=typo3 typo3 > $(dirname "$0")/../../data/typo3_backup.sql

--- a/container/bin/composer-install.sh
+++ b/container/bin/composer-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get php container id
-container=$(docker ps -qf "name=t3apprenticeship_php_1")
+container=$(docker ps -qf "name=masheuskirchen_php_1")
 
 # run composer install as non root user
 docker exec -it $container composer install

--- a/container/bin/import_db.sh
+++ b/container/bin/import_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get container id
-container=$(docker ps -aqf "name=t3apprenticeship_db_1")
+container=$(docker ps -aqf "name=masheuskirchen_db_1")
 
 # path to backupfile
 file=$(dirname "$0")/../../data/typo3_backup.sql


### PR DESCRIPTION
The id of the container is searched by the bashscripts via the container name. The search input has been adapted.